### PR TITLE
feat: add prev and next month

### DIFF
--- a/src/components/App/App.module.scss
+++ b/src/components/App/App.module.scss
@@ -15,6 +15,6 @@
 .container {
   &__datePicker {
     margin: 0 auto;
-    width: 250px;
+    width: 267px;
   }
 }

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -21,8 +21,8 @@ const DatePicker: React.FC = () => {
   const [active, setActive] = useState<boolean>(false);
   const [selectedDay, setSelectedDay] = useState<number | null>(null);
 
-  const controlInputRef = useRef<HTMLInputElement | null>(null);
-  const monthCardRef = useRef<HTMLDivElement | null>(null);
+  const controlInputRef = useRef<HTMLInputElement>(null);
+  const monthCardRef = useRef<HTMLDivElement>(null);
   const { theme } = useTheme();
 
   // Effect to update the date input with the current day.
@@ -81,8 +81,6 @@ const DatePicker: React.FC = () => {
           onFocus={(e) => setActive(true)}
         />
         <InputGroup.Text id="cal_icon" className={inputGroupTheme}>
-          {/* <svg className="footer__icon-github"> */}
-
           <svg className={calendar_icon_classes}>
             <use href={`${sprite}#icon-calendar`}></use>
           </svg>

--- a/src/components/MonthCard/MonthCard.module.scss
+++ b/src/components/MonthCard/MonthCard.module.scss
@@ -4,19 +4,17 @@
   &__container {
     position: absolute;
     top: 39px;
-    left: 64px;
-    width: 204px;
+    left: -140px;
+    width: auto;
     height: auto;
-    border: 1px solid #dee2e6;
+    display: flex;
+    flex-direction: column;
+    &-box {
+      align-self: flex-start;
+      width: 204px;
+    }
   }
-  // &__container--isPrevious-month {
-  //   left: -139px;
-  //   width: 204px;
-  // }
-  // &__container--isNext-month {
-  //   left: 205px;
-  //   width: 204px;
-  // }
+
   &__icon-prevMonth,
   &__icon-nextMonth {
     width: 1.4rem;
@@ -30,12 +28,14 @@
     }
   }
   &__weekday {
+    width: 25px;
+    height: 25px;
     font-size: 12px;
-    width: 1.8rem;
-    height: 1.4rem;
+    margin: 2px;
     display: flex;
     justify-content: center;
     align-items: center;
+
     &--light {
       background-color: var(--bs-gray-400);
     }
@@ -43,18 +43,20 @@
       background-color: var(--bs-gray-600);
     }
   }
-
-  &__toggleMonth--dark {
-    background-color: var(--bs-gray-600);
-  }
-  &__toggleMonth--light {
-    background-color: var(--bs-gray-400);
+  // monthCard__toggleMonth
+  &__toggleMonth {
+    &--dark {
+      background-color: var(--bs-gray-600);
+    }
+    &--light {
+      background-color: var(--bs-gray-400);
+    }
   }
 
   &__day {
     cursor: pointer;
-    width: 1.8rem;
-    height: 1.4rem;
+    width: 25px;
+    height: 25px;
     font-size: 12px;
     border-radius: 5px;
     margin: 2px;

--- a/src/components/MonthCard/MonthCard.tsx
+++ b/src/components/MonthCard/MonthCard.tsx
@@ -12,15 +12,19 @@ interface MonthCardProps {
   setTime: Dispatch<React.SetStateAction<number>>;
   selectedDay: number | null;
   setSelectedDay: Dispatch<React.SetStateAction<number | null>>;
-  isPrev?: boolean;
-  isNext?: boolean;
 }
+
+type Param = ReturnType<typeof getParam>;
 
 const MonthCard: React.ForwardRefExoticComponent<
   React.RefAttributes<HTMLDivElement> & MonthCardProps
-> = forwardRef(function ({ time, setTime, selectedDay, setSelectedDay, isPrev, isNext }, ref) {
+> = forwardRef(function ({ time, setTime, selectedDay, setSelectedDay }, ref) {
   const param = getParam(time);
   const { theme } = useTheme();
+  const prevMonthTime = new Date(time).setMonth(new Date(time).getMonth() - 1);
+  const nextMonthTime = new Date(time).setMonth(new Date(time).getMonth() + 1);
+  const paramPrevMonth = getParam(prevMonthTime);
+  const paramNextMonth = getParam(nextMonthTime);
 
   // Toggle month theme classNames
   const togglemonth = cx({
@@ -31,19 +35,21 @@ const MonthCard: React.ForwardRefExoticComponent<
   //
   const togglemonth_classes = classNames(
     styles[togglemonth],
+    styles[`monthCard__toggleMonth`],
     `d-flex`,
     `justify-content-between`,
     `align-items-center`
   );
 
-  const monthDay_classes = classNames(
-    styles['monthCard__weekday'],
+  const weekDay_classes = classNames(
     styles[
       cx({
         'monthCard__weekday--light': theme === 'light',
         'monthCard__weekday--dark': theme === 'dark',
       })
-    ]
+    ],
+    'd-flex',
+    'justify-content-center'
   );
 
   // previous Day in month classNames
@@ -74,6 +80,8 @@ const MonthCard: React.ForwardRefExoticComponent<
     ]
   );
 
+  const box_classes = classNames(styles['monthCard__container-box'], 'd-flex', 'flex-wrap', 'text');
+
   const handleSelectedDay = (e: MouseEvent<HTMLElement>, time: number) => {
     setTime(time);
     const value = (e.target as HTMLElement).innerText;
@@ -84,14 +92,14 @@ const MonthCard: React.ForwardRefExoticComponent<
   const weekHeader = () => {
     const dayList = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'];
     return dayList.map((day, i) => (
-      <div key={`${day}-${i}`} className={monthDay_classes}>
+      <div key={`${day}-${i}`} className={styles['monthCard__weekday']}>
         {day}
       </div>
     ));
   };
 
   // get all the day from the previous Month
-  const prevMonth = () => {
+  const prevMonth = (param: Param) => {
     const { prevMonthDays, timeFirstDay } = param;
     return prevMonthDays
       .map((day, i) => {
@@ -111,7 +119,7 @@ const MonthCard: React.ForwardRefExoticComponent<
   };
 
   // function to render all the day from 1 to 28/29 if Feb. otherwise 30/31
-  const dayInMonth = (nbDays: number) => {
+  const dayInMonth = (nbDays: number, param: Param) => {
     const arrayLength = { length: nbDays };
     const monthArr = Array.from(arrayLength, (v, i) => i);
     const { timeFirstDay, day: selectedDay } = param;
@@ -141,7 +149,7 @@ const MonthCard: React.ForwardRefExoticComponent<
   };
 
   // function to render all the days in next month to complete the current row in the current month
-  const nextMonth = () => {
+  const nextMonth = (param: Param) => {
     const { nextMonthDays, timeLastDay } = param;
     if (!nextMonthDays) return;
     return nextMonthDays.map((day, i) => {
@@ -179,33 +187,38 @@ const MonthCard: React.ForwardRefExoticComponent<
 
   return (
     <div ref={ref} className={styles['monthCard__container']}>
-      <div className={togglemonth_classes}>
-        <svg className={icon_prev_classes} onClick={handleGoToPreviousMonth}>
-          <use href={`${sprite}#icon-triangle-left`}></use>
-        </svg>
-        <span>{`${param.fullMonth} ${param.year}`}</span>
-        <svg className={icon_next_classes} onClick={handleGoToNextMonth}>
-          <use href={`${sprite}#icon-triangle-right`}> </use>
-        </svg>
+      <div>
+        <div className="col-4 offset-4">
+          <div className={togglemonth_classes}>
+            <svg className={icon_prev_classes} onClick={handleGoToPreviousMonth}>
+              <use href={`${sprite}#icon-triangle-left`} className="text"></use>
+            </svg>
+            <span>{`${param.fullMonth} ${param.year}`}</span>
+            <svg className={icon_next_classes} onClick={handleGoToNextMonth}>
+              <use href={`${sprite}#icon-triangle-right`}> </use>
+            </svg>
+          </div>
+          <div className={weekDay_classes}>{weekHeader()}</div>
+        </div>
       </div>
-      <div className={'d-flex justify-content-center'}>{weekHeader()}</div>
-      {/* <div className="d-flex flex-row"> */}
-      {/* <div className="d-flex flex-wrap text">
-          {param && param.weekDayFirstOfMonth >= 0 && prevMonth()}
-          {dayInMonth(param.numberOfDayInMonth)}
-          {nextMonth()}
-        </div> */}
-      <div className="d-flex flex-wrap text">
-        {param && param.weekDayFirstOfMonth >= 0 && prevMonth()}
-        {dayInMonth(param.numberOfDayInMonth)}
-        {nextMonth()}
+      <div className="d-flex">
+        <div className={box_classes}>
+          {paramPrevMonth && paramPrevMonth.weekDayFirstOfMonth >= 0 && prevMonth(paramPrevMonth)}
+          {dayInMonth(paramPrevMonth.numberOfDayInMonth, paramPrevMonth)}
+          {nextMonth(paramPrevMonth)}
+        </div>
+        <div className={box_classes}>
+          {param && param.weekDayFirstOfMonth >= 0 && prevMonth(param)}
+          {dayInMonth(param.numberOfDayInMonth, param)}
+          {nextMonth(param)}
+        </div>
+        <div className={box_classes}>
+          {paramNextMonth && paramNextMonth.weekDayFirstOfMonth >= 0 && prevMonth(paramNextMonth)}
+          {dayInMonth(paramNextMonth.numberOfDayInMonth, paramNextMonth)}
+          {nextMonth(paramNextMonth)}
+        </div>
+        {/* </div> */}
       </div>
-      {/* <div className="d-flex flex-wrap text">
-          {param && param.weekDayFirstOfMonth >= 0 && prevMonth()}
-          {dayInMonth(param.numberOfDayInMonth)}
-          {nextMonth()}
-        </div> */}
-      {/* </div> */}
     </div>
   );
 });


### PR DESCRIPTION

Add previous and next month card aside to the selected month and set up the css for animation which will be next PR.


![Screenshot 2024-03-22 at 20 27 57](https://github.com/stephane777/timeplayground/assets/33736198/7e7c7b96-eeac-4386-890c-f111049f5c87)
